### PR TITLE
add client-side cache to prevent redundant network calls

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,16 +2,23 @@
  * Root layout - wraps app with providers and loads fonts
  */
 
+import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { useFonts } from 'expo-font';
 import { AuthProvider } from '../src/auth/context';
 import { ThemeProvider } from '../src/theme/context';
+import { objectCache } from '../src/cache/objectCache';
 
 export default function RootLayout() {
     const [fontsLoaded] = useFonts({
         'Helvetica': require('../assets/fonts/helvetica.ttf'),
         'LoftSans': require('../assets/fonts/WilcoLoftSans-Treble.ttf'),
     });
+
+    // Hydrate object cache from AsyncStorage on app start
+    useEffect(() => {
+        objectCache.initialize();
+    }, []);
 
     if (!fontsLoaded) {
         return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "extrachill-app",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extrachill-app",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-google-signin/google-signin": "^13.0.0",
         "@react-navigation/drawer": "^7.7.10",
         "babel-preset-expo": "~54.0.8",
@@ -1439,7 +1440,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1555,6 +1555,7 @@
       "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
       "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hammerjs": "^2.0.36"
       },
@@ -2944,6 +2945,18 @@
         }
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native-google-signin/google-signin": {
       "version": "13.3.1",
       "resolved": "https://registry.npmjs.org/@react-native-google-signin/google-signin/-/google-signin-13.3.1.tgz",
@@ -3278,7 +3291,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/drawer/-/drawer-7.7.10.tgz",
       "integrity": "sha512-FGYU5Ebd2whTa4Z+RBCxnWqmyWIQGTJ7PAAhk2RjlVrEXLU0HaFR5JGmEHuNm/Cm9xX3xCwOxYZiA0Xi/DeyAA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/elements": "^2.9.3",
         "color": "^4.2.3",
@@ -3323,7 +3335,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.26.tgz",
       "integrity": "sha512-RhKmeD0E2ejzKS6z8elAfdfwShpcdkYY8zJzvHYLq+wv183BBcElTeyMLcIX6wIn7QutXeI92Yi21t7aUWfqNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.13.7",
         "escape-string-regexp": "^4.0.0",
@@ -3454,7 +3465,8 @@
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -3495,7 +3507,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4160,7 +4171,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4951,7 +4961,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.29.tgz",
       "integrity": "sha512-9C90gyOzV83y2S3XzCbRDCuKYNaiyCzuP9ketv46acHCEZn+QTamPK/DobdghoSiofCmlfoaiD6/SzfxDiHMnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.19",
@@ -5004,7 +5013,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.12.tgz",
       "integrity": "sha512-WzcKYMVNRRu4NcSzfIVRD5aUQFnSpTZgXFrlWmm19xJoDa4S3/PQNi6PNTBRc49xz9h8FT7HMxRKaC8lr0gflA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.12",
         "@expo/env": "~2.0.8"
@@ -5031,7 +5039,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.10.tgz",
       "integrity": "sha512-UqyNaaLKRpj4pKAP4HZSLnuDQqueaO5tB1c/NWu5vh1/LF9ulItyyg2kF/IpeOp0DeOLk0GY0HrIXaKUMrwB+Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -5046,7 +5053,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.10.tgz",
       "integrity": "sha512-0EKtn4Sk6OYmb/5ZqK8riO0k1Ic+wyT3xExbmDvUYhT7p/cKqlVUExMuOIAt3Cx3KUUU1WCgGmdd493W/D5XjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.11",
         "invariant": "^2.2.4"
@@ -6101,6 +6107,7 @@
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "react-is": "^16.7.0"
       }
@@ -6109,7 +6116,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -6308,6 +6316,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-wsl": {
@@ -7213,6 +7230,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -8274,7 +8303,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8294,7 +8322,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -8331,7 +8358,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -8431,7 +8457,6 @@
       "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.1.6.tgz",
       "integrity": "sha512-F+ZJBYiok/6Jzp1re75F/9aLzkgoQCOh4yxrnwATa8392RvM3kx+fiXXFvwcgE59v48lMwd9q0nzF1oJLXpfxQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-native-is-edge-to-edge": "^1.2.1",
         "semver": "7.7.2"
@@ -8460,7 +8485,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -8471,7 +8495,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -8622,7 +8645,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9623,7 +9645,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-google-signin/google-signin": "^13.0.0",
     "@react-navigation/drawer": "^7.7.10",
     "babel-preset-expo": "~54.0.8",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -5,7 +5,7 @@
  * Uses a refresh lock to prevent thundering herd on concurrent 401s.
  */
 
-import type { LoginResponse, RegisterResponse, RefreshResponse, BrowserHandoffResponse, AuthMeResponse, ActivityResponse, ApiError, OnboardingStatusResponse, OnboardingSubmitResponse, OAuthConfigResponse, GoogleLoginResponse } from '../types/api';
+import type { LoginResponse, RegisterResponse, RefreshResponse, BrowserHandoffResponse, AuthMeResponse, ActivityResponse, ApiError, OnboardingStatusResponse, OnboardingSubmitResponse, OAuthConfigResponse, GoogleLoginResponse, HydratedObject } from '../types/api';
 import { storeTokens, getTokens, clearTokens, getDeviceId, type StoredTokens } from '../auth/storage';
 
 const API_BASE = 'https://extrachill.com/wp-json/extrachill/v1';
@@ -330,6 +330,18 @@ class ApiClient {
         params.append('limit', limit.toString());
 
         return this.request<ActivityResponse>(`/activity?${params.toString()}`);
+    }
+
+    /**
+     * Hydrate a feed reference into a detail payload.
+     */
+    async getObject(objectType: string, blogId: number, id: string): Promise<HydratedObject> {
+        const params = new URLSearchParams();
+        params.append('object_type', objectType);
+        params.append('blog_id', blogId.toString());
+        params.append('id', id);
+
+        return this.request<HydratedObject>(`/object?${params.toString()}`);
     }
 
     /**

--- a/src/hooks/useObject.ts
+++ b/src/hooks/useObject.ts
@@ -1,0 +1,99 @@
+/**
+ * React hook for fetching and caching hydrated objects.
+ *
+ * Implements stale-while-revalidate:
+ *   - Cache hit (fresh) → return immediately, no network call
+ *   - Cache hit (stale) → return stale data, refresh in background
+ *   - Cache miss → show loading, fetch from network
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import type { HydratedObject } from '@/types/api';
+import { objectCache } from '@/cache/objectCache';
+import { api } from '@/api/client';
+
+interface UseObjectResult {
+    data: HydratedObject | null;
+    isLoading: boolean;
+    error: string | null;
+    refresh: () => Promise<void>;
+}
+
+export function useObject(
+    objectType: string,
+    blogId: number,
+    id: string
+): UseObjectResult {
+    const [data, setData] = useState<HydratedObject | null>(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    // Track mounted state to avoid setState after unmount
+    const mountedRef = useRef(true);
+
+    const fetchAndCache = useCallback(async () => {
+        try {
+            const result = await api.getObject(objectType, blogId, id);
+            await objectCache.set(objectType, blogId, id, result);
+
+            if (mountedRef.current) {
+                setData(result);
+                setError(null);
+            }
+        } catch (err) {
+            if (mountedRef.current) {
+                setError(err instanceof Error ? err.message : 'Failed to load content');
+            }
+        } finally {
+            if (mountedRef.current) {
+                setIsLoading(false);
+            }
+        }
+    }, [objectType, blogId, id]);
+
+    useEffect(() => {
+        mountedRef.current = true;
+
+        // Check cache first
+        const cached = objectCache.get(objectType, blogId, id);
+
+        if (cached) {
+            // Fresh cache hit — use it, no network call needed
+            setData(cached.data);
+            setIsLoading(false);
+            setError(null);
+            return;
+        }
+
+        // Check for stale data (expired but present)
+        const stale = objectCache.getStale(objectType, blogId, id);
+
+        if (stale) {
+            // Stale-while-revalidate: show old data immediately
+            setData(stale.data);
+            setIsLoading(false);
+            setError(null);
+
+            // Refresh in background (don't set loading state)
+            fetchAndCache();
+            return;
+        }
+
+        // Cache miss — fetch from network
+        setIsLoading(true);
+        setError(null);
+        fetchAndCache();
+
+        return () => {
+            mountedRef.current = false;
+        };
+    }, [objectType, blogId, id, fetchAndCache]);
+
+    const refresh = useCallback(async () => {
+        setIsLoading(true);
+        setError(null);
+        await fetchAndCache();
+    }, [fetchAndCache]);
+
+    return { data, isLoading, error, refresh };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -98,6 +98,31 @@ export interface ApiError {
     };
 }
 
+// Object Hydration Types
+
+/**
+ * Common fields returned by GET /object for all object types.
+ * The `data` field contains type-specific content.
+ */
+export interface HydratedObject {
+    object_type: string;
+    blog_id: number;
+    id: string;
+    title?: string;
+    content?: string;
+    excerpt?: string;
+    permalink?: string;
+    author?: {
+        id: number;
+        display_name: string;
+        avatar_url?: string;
+    };
+    created_at?: string;
+    updated_at?: string;
+    /** Type-specific payload — shape depends on object_type */
+    data?: Record<string, unknown>;
+}
+
 // Activity Feed Types
 export interface ActivityObject {
     object_type: string;


### PR DESCRIPTION
[Issue #12 ](https://github.com/Extra-Chill/extrachill-app/issues/12)
Previously, viewing content (posts, comments, etc.) required a network call every time. Now, a client-side cache stores hydrated objects locally so repeat views load instantly and previously viewed content is available offline.

More details: 

- Added @react-native-async-storage/async-storage for persistent storage
- Added HydratedObject type and api.getObject() method for the GET /object endpoint
- Created src/cache/objectCache.ts — two-tier cache (in-memory Map + AsyncStorage) with 5-minute TTL, 200-entry cap, and LRU eviction
- Created src/hooks/useObject.ts — React hook with stale-while-revalidate (shows cached data instantly while refreshing in background)
- Cache initializes from AsyncStorage on app start in root layout