### PR TITLE
feat: migrate onboarding to ability calls (#26)

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -16,7 +16,8 @@ import {
 import { useRouter } from 'expo-router';
 import { useAuth } from '../src/auth/context';
 import { useTheme } from '../src/theme/context';
-import { api } from '../src/api/client';
+import { queryAbility } from '../src/api/abilities';
+import type { OnboardingStatusResponse } from '../src/types/api';
 
 import { Button, TextInput, Notice, Checkbox } from '../src/components';
 
@@ -35,7 +36,7 @@ export default function Onboarding() {
     useEffect(() => {
         const fetchOnboardingStatus = async () => {
             try {
-                const status = await api.users.getOnboardingStatus();
+                const status = await queryAbility<OnboardingStatusResponse>('extrachill/get-onboarding-status');
                 setUsername(status.fields.username);
                 setIsArtist(status.fields.user_is_artist);
                 setIsProfessional(status.fields.user_is_professional);

--- a/src/api/abilities.ts
+++ b/src/api/abilities.ts
@@ -1,0 +1,57 @@
+/**
+ * Ability execution helper.
+ *
+ * Calls abilities via the wp-abilities REST endpoint:
+ *   POST /wp-json/wp-abilities/v1/abilities/{name}/run
+ *   GET  /wp-json/wp-abilities/v1/abilities/{name}/run
+ *
+ * The REST endpoint wraps every result in `{ result: <value> }`. These
+ * helpers unwrap the envelope so callers receive the value directly.
+ *
+ * Auth is handled by AuthFetchTransport (Bearer token from secure storage).
+ */
+
+import { transport } from './client';
+
+/**
+ * The wire-format envelope returned by /wp-abilities/v1/abilities/{name}/run.
+ */
+interface AbilityResponse<T> {
+  result: T;
+}
+
+/**
+ * Execute a mutating ability (POST).
+ *
+ * Sends `{ input }` in the request body and returns the unwrapped result.
+ */
+export async function executeAbility<T = unknown>(
+  abilityName: string,
+  input: Record<string, unknown> | null = null,
+): Promise<T> {
+  const response = await transport.request<AbilityResponse<T>>({
+    path: `wp-abilities/v1/abilities/${abilityName}/run`,
+    method: 'POST',
+    body: { input },
+  });
+  return response.result;
+}
+
+/**
+ * Execute a readonly ability (GET).
+ *
+ * Passes input as a JSON-encoded query parameter.
+ * Use this for abilities annotated with `readonly: true`. Returns the
+ * unwrapped result (same envelope handling as `executeAbility`).
+ */
+export async function queryAbility<T = unknown>(
+  abilityName: string,
+  input?: Record<string, unknown>,
+): Promise<T> {
+  const query = input ? `?input=${encodeURIComponent(JSON.stringify(input))}` : '';
+  const response = await transport.request<AbilityResponse<T>>({
+    path: `wp-abilities/v1/abilities/${abilityName}/run${query}`,
+    method: 'GET',
+  });
+  return response.result;
+}

--- a/src/auth/context.tsx
+++ b/src/auth/context.tsx
@@ -11,8 +11,9 @@
 
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { Platform } from 'react-native';
-import type { AuthMeResponse, OAuthConfigResponse } from '../types/api';
+import type { AuthMeResponse, OAuthConfigResponse, OnboardingStatusResponse, OnboardingSubmitResponse } from '../types/api';
 import { api, transport } from '../api/client';
+import { executeAbility, queryAbility } from '../api/abilities';
 import { getDeviceId } from './storage';
 
 let googleSignInModule: typeof import('@react-native-google-signin/google-signin') | null = null;
@@ -119,7 +120,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         try {
             const user = await api.auth.me();
-            const onboardingStatus = await api.users.getOnboardingStatus();
+            const onboardingStatus = await queryAbility<OnboardingStatusResponse>('extrachill/get-onboarding-status');
             setState({
                 user,
                 isLoading: false,
@@ -156,7 +157,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
         const [me, onboardingStatus] = await Promise.all([
             api.auth.me(),
-            api.users.getOnboardingStatus(),
+            queryAbility<OnboardingStatusResponse>('extrachill/get-onboarding-status'),
         ]);
 
         setState(prev => ({
@@ -239,7 +240,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
             const [me, onboardingStatus] = await Promise.all([
                 api.auth.me(),
-                api.users.getOnboardingStatus(),
+                queryAbility<OnboardingStatusResponse>('extrachill/get-onboarding-status'),
             ]);
 
             setState(prev => ({
@@ -274,7 +275,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         userIsArtist: boolean,
         userIsProfessional: boolean
     ) => {
-        const response = await api.users.submitOnboarding({
+        const response = await executeAbility<OnboardingSubmitResponse>('extrachill/complete-onboarding', {
             username,
             user_is_artist: userIsArtist,
             user_is_professional: userIsProfessional,


### PR DESCRIPTION
## Summary

Closes #26.

Migrates the two onboarding REST callsites from `@extrachill/api-client` REST methods to the canonical wp-abilities endpoint:

- `api.users.getOnboardingStatus()` → `queryAbility<OnboardingStatusResponse>('extrachill/get-onboarding-status')` (GET)
- `api.users.submitOnboarding(data)` → `executeAbility<OnboardingSubmitResponse>('extrachill/complete-onboarding', data)` (POST)

## Changes

- **`src/api/abilities.ts`** (new) — `executeAbility()` (POST for mutating abilities) and `queryAbility()` (GET for readonly abilities). Both use the existing `AuthFetchTransport` for auth.
- **`src/auth/context.tsx`** — Replaced 4 callsites (checkAuth, login, loginWithGoogle, completeOnboarding)
- **`app/onboarding.tsx`** — Replaced 1 callsite (fetchOnboardingStatus in useEffect)

## Server-side prerequisite

The three abilities (`extrachill/get-onboarding-status`, `extrachill/complete-onboarding`, `extrachill/validate-username`) were confirmed to exist on extrachill.com per the [EC abilities audit](https://github.com/chubes4/wp-native/blob/main/docs/EC-ABILITIES-AUDIT.md). Their `show_in_rest` and `user_id` defaults have been updated server-side to support direct ability REST calls.

## Verification

- `npx tsc --noEmit` passes (exit 0)
- No `any` types introduced
- All existing types from `@extrachill/api-client` reused (no type changes)

## Out of scope (M7.2)

Auth flows remain on REST — login, logout, /me, register, OAuth, browser handoff are **not** touched. Those depend on wp-native-auth migration (tracked in #24).