### PR TITLE
feat: add wp-native-client + wp-native-shell deps (#30)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.4.0",
       "dependencies": {
         "@extrachill/api-client": "^0.2.0",
-        "@extrachill/tokens": "^0.1.0",
+        "@extrachill/tokens": "^0.2.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-google-signin/google-signin": "^13.0.0",
         "@react-navigation/drawer": "^7.7.10",
+        "@react-navigation/native": "^7.1.26",
+        "@react-navigation/native-stack": "^7.9.0",
         "babel-preset-expo": "~54.0.8",
         "expo": "~54.0.29",
         "expo-constants": "~18.0.12",
@@ -29,7 +31,9 @@
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
         "react-native-svg": "15.12.1",
-        "react-native-worklets": "0.5.1"
+        "react-native-worklets": "0.5.1",
+        "wp-native-client": "^0.0.1",
+        "wp-native-shell": "^0.0.1"
       },
       "devDependencies": {
         "@types/react": "~19.1.0",
@@ -2397,9 +2401,9 @@
       "license": "GPL-2.0+"
     },
     "node_modules/@extrachill/tokens": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@extrachill/tokens/-/tokens-0.1.0.tgz",
-      "integrity": "sha512-OxZojk2+DyupwPfXB3xQ0qASudpglsJaaRW6eNIQk9FSHhLyu1HRg0g1o/FJ70ZGczNAfgBYYXNlXGP2FVzO+w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@extrachill/tokens/-/tokens-0.2.0.tgz",
+      "integrity": "sha512-5vEjcX5qAQhjHoqD1nL3nsYzpiLiIGDilP6eDnJH7jektyZQ3HKN7C0Mkn5O3E2hwxwV5Fff0gh3uO8GFnLxnA==",
       "license": "GPL-2.0+"
     },
     "node_modules/@isaacs/balanced-match": {
@@ -10209,6 +10213,27 @@
       "resolved": "https://registry.npmjs.org/wonka/-/wonka-6.3.5.tgz",
       "integrity": "sha512-SSil+ecw6B4/Dm7Pf2sAshKQ5hWFvfyGlfPbEd6A14dOH6VDjrmbY86u6nZvy9omGwwIPFR8V41+of1EezgoUw==",
       "license": "MIT"
+    },
+    "node_modules/wp-native-client": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/wp-native-client/-/wp-native-client-0.0.1.tgz",
+      "integrity": "sha512-V2v1eCsmwWmAC1U3WeGPXLeESXoKiLZGxWiWOtBpg/1gVlofR4z6GDIA+jTxH2Z70CcfD/S+rTnMr9SNAkLD8w==",
+      "license": "GPL-2.0-or-later"
+    },
+    "node_modules/wp-native-shell": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/wp-native-shell/-/wp-native-shell-0.0.1.tgz",
+      "integrity": "sha512-yBQh70YarOKmHCSioSKLTkdPfXPqWXtVzFTL3YJgsoScHSxx9tligWE3BIpOz4x+ghSjp9lr9obhDnKJsk2wkg==",
+      "license": "GPL-2.0-or-later",
+      "peerDependencies": {
+        "@react-navigation/drawer": ">=7",
+        "@react-navigation/native": ">=7",
+        "@react-navigation/native-stack": ">=7",
+        "expo-router": ">=6",
+        "react": ">=19",
+        "react-native": ">=0.80",
+        "wp-native-client": "*"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-google-signin/google-signin": "^13.0.0",
     "@react-navigation/drawer": "^7.7.10",
+    "@react-navigation/native": "^7.1.26",
+    "@react-navigation/native-stack": "^7.9.0",
     "babel-preset-expo": "~54.0.8",
     "expo": "~54.0.29",
     "expo-constants": "~18.0.12",
@@ -31,7 +33,9 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-svg": "15.12.1",
-    "react-native-worklets": "0.5.1"
+    "react-native-worklets": "0.5.1",
+    "wp-native-client": "^0.0.1",
+    "wp-native-shell": "^0.0.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/src/__smoke__/wp-native-imports.ts
+++ b/src/__smoke__/wp-native-imports.ts
@@ -1,0 +1,13 @@
+/**
+ * Smoke test for M7.2.2 — verifies wp-native-client + wp-native-shell
+ * are installed and resolvable. Excluded from the main tsconfig include.
+ *
+ * Delete this file when M7.2.5 lands (<WPNativeApp/> mounted means the
+ * imports are already exercised by real code).
+ */
+import type { WPNativeConfig, AuthState, ThemeTokens } from 'wp-native-shell';
+import { WPNativeClient } from 'wp-native-client';
+
+// Reference each import so unused-import checks don't flag them.
+export type { WPNativeConfig, AuthState, ThemeTokens };
+export { WPNativeClient };


### PR DESCRIPTION
## Summary

Adds [`wp-native-client`](https://www.npmjs.com/package/wp-native-client) and [`wp-native-shell`](https://www.npmjs.com/package/wp-native-shell) (both v0.0.1) as dependencies for the M7.2 wp-native migration.

Closes #30 — part of the M7.2 sub-issue chain tracked in #27.

## Changes

- **package.json**: added `wp-native-client@^0.0.1` and `wp-native-shell@^0.0.1` to `dependencies`
- **package.json**: promoted `@react-navigation/native` and `@react-navigation/native-stack` to direct dependencies (previously only transitive via expo-router / drawer) — required as peer deps of `wp-native-shell`
- **src/__smoke__/wp-native-imports.ts**: temporary smoke-test file that re-exports key types/classes from both packages to verify they resolve. Will be deleted when M7.2.5 mounts `<WPNativeApp/>`
- `@extrachill/api-client` is **intentionally kept** — retires in M8

## Verification

- `npm install` resolves both packages cleanly (2 packages added)
- `npx tsc --noEmit` exits 0 — all imports typecheck under strict mode

## What's next

This is a deps-only PR. No app code changes yet:
- **M7.2.3** swaps the auth provider to `wp-native-shell`
- **M7.2.5** mounts `<WPNativeApp/>` and deletes the smoke-test file