### PR TITLE
feat: add extrachill.config.ts (#29)

### DIFF
--- a/extrachill.config.ts
+++ b/extrachill.config.ts
@@ -1,0 +1,67 @@
+/**
+ * extrachill.config.ts — Extra Chill app config for wp-native-shell.
+ *
+ * Consumed by <WPNativeApp config={config}/> in app/_layout.tsx (M7.2.5).
+ * Until then, this file is dormant — its presence verifies the SHELL.md
+ * contract type-checks against EC's specifics.
+ */
+
+import type { WPNativeConfig, AuthState } from 'wp-native-shell';
+import { secureStoreAdapter } from './src/auth/storage';
+import OnboardingScreen from './app/onboarding';
+
+export const config: WPNativeConfig = {
+  api: {
+    baseUrl: 'https://extrachill.com/wp-json',
+    clientId: 'extrachill-app',
+    defaultHeaders: { 'ExtraChill-Client': 'app' },
+  },
+
+  brand: {
+    name: 'Extra Chill',
+    welcomeMessage: 'Welcome to Extra Chill',
+  },
+
+  tokenStorage: secureStoreAdapter,
+
+  navigation: {
+    sections: [
+      // Initial sections render as placeholders (M5.3 fallback) until
+      // list/detail adapters land in follow-up issues.
+      {
+        id: 'feed',
+        label: 'Feed',
+        ability: 'wp/post.list',
+        visibleWhen: (auth: AuthState) => auth.isAuthenticated,
+      },
+      // More sections added in follow-up issues. Keep this list minimal
+      // for the first end-to-end dogfood.
+    ],
+  },
+
+  browserHandoff: {
+    handoffHosts: ['extrachill.com', '*.extrachill.com'],
+    excludeHosts: ['*.extrachill.link'],
+    handoffAbility: 'wp-native/auth-browser-handoff',
+  },
+
+  // Theme overrides — pull EC-specific tokens, fall back to defaults
+  // for everything else. Spread merges via wp-native-shell's
+  // deepMergeTokens at runtime.
+  theme: {
+    colors: {
+      // TODO(M7.2): pull from @extrachill/tokens when the migration lands.
+      // For now, leave defaults from wp-native-shell.
+    },
+    typography: {
+      fontFamily: 'WilcoLoftSans',
+      fontFamilyBold: 'WilcoLoftSans-Bold',
+    },
+  },
+
+  onboarding: {
+    enabled: true,
+    ability: 'extrachill/complete-onboarding',
+    screen: OnboardingScreen,
+  },
+};

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -4,6 +4,10 @@
 
 import * as SecureStore from 'expo-secure-store';
 import * as Crypto from 'expo-crypto';
+import type {
+  TokenStorageAdapter,
+  StoredTokens as ShellStoredTokens,
+} from 'wp-native-shell';
 
 const KEYS = {
     ACCESS_TOKEN: 'access_token',
@@ -60,3 +64,34 @@ export async function clearTokens(): Promise<void> {
         SecureStore.deleteItemAsync(KEYS.ACCESS_EXPIRY),
     ]);
 }
+
+/**
+ * Adapter that wraps EC's expo-secure-store helpers into wp-native-shell's
+ * TokenStorageAdapter interface. Used by extrachill.config.ts.
+ */
+export const secureStoreAdapter: TokenStorageAdapter = {
+    load: async (): Promise<ShellStoredTokens | null> => {
+        const tokens = await getTokens();
+        if (
+            !tokens.accessToken ||
+            !tokens.refreshToken ||
+            tokens.accessExpiresAt === null
+        ) {
+            return null;
+        }
+        return {
+            accessToken: tokens.accessToken,
+            refreshToken: tokens.refreshToken,
+            accessExpiresAt: tokens.accessExpiresAt,
+        };
+    },
+    save: async (tokens: ShellStoredTokens): Promise<void> => {
+        await storeTokens(
+            tokens.accessToken,
+            tokens.refreshToken,
+            tokens.accessExpiresAt,
+        );
+    },
+    clear: clearTokens,
+    getDeviceId,
+};


### PR DESCRIPTION
## Summary

Creates `extrachill.config.ts` at the repo root — the EC-specific consumer config for wp-native-shell's `<WPNativeApp/>`.

Closes #29.

## What's in this PR

- **`extrachill.config.ts`** — Matches the `WPNativeConfig` shape from [`packages/shell/SHELL.md`](https://github.com/chubes4/wp-native/blob/main/packages/shell/SHELL.md). Configures:
  - `api` — EC's WordPress REST API endpoint + client identifier
  - `brand` — app name + welcome message
  - `tokenStorage` — `secureStoreAdapter` wrapping EC's expo-secure-store helpers
  - `navigation` — minimal sections list (one `feed` section) — more land in follow-up issues
  - `browserHandoff` — handoff hosts for extrachill.com
  - `theme` — WilcoLoftSans typography, colors deferred to `@extrachill/tokens` migration
  - `onboarding` — enabled, wired to the existing `app/onboarding.tsx` screen

- **`src/auth/storage.ts`** — Adds a new `secureStoreAdapter` export that wraps the existing `getTokens`, `storeTokens`, `clearTokens`, and `getDeviceId` functions into wp-native-shell's `TokenStorageAdapter` interface. All existing exports preserved.

## Type-check status

`npx tsc --noEmit` produces only the expected `Cannot find module 'wp-native-shell'` errors — because wp-native-shell isn't in deps yet. That resolution happens when **M7.2.2 (#30)** merges and adds the wp-native packages to dependencies. No structural or `any` errors.

## Cross-references

- **M7.2.2 (#30)** — parallel PR that adds wp-native-shell + wp-native-client as dependencies. Once merged, the type imports in this PR resolve cleanly.
- **SHELL.md contract** — [`packages/shell/SHELL.md`](https://github.com/chubes4/wp-native/blob/main/packages/shell/SHELL.md) defines the `WPNativeConfig` shape this file implements.
- **M7.2.5** — future PR that mounts `<WPNativeApp config={config}/>` in `app/_layout.tsx`, consuming this config.