### PR TITLE
docs(api): document M7.2.5 abilities.ts refactor plan (M7.2.4)

### DIFF
--- a/src/api/abilities.ts
+++ b/src/api/abilities.ts
@@ -9,6 +9,16 @@
  * helpers unwrap the envelope so callers receive the value directly.
  *
  * Auth is handled by AuthFetchTransport (Bearer token from secure storage).
+ *
+ * TODO(M7.2.5): replace `transport` import with useAuth().client from
+ * wp-native-shell, and convert executeAbility / queryAbility to a hook
+ * (useExecuteAbility) called from inside components. The current
+ * implementation depends on `src/api/client.ts` which gets deleted
+ * when <WPNativeApp/> mounts — wp-native-shell's AuthProvider builds
+ * its own AuthFetchTransport from config.tokenStorage.
+ *
+ * Until M7.2.5 lands, this file uses the global `transport` because
+ * the wp-native AuthProvider isn't mounted yet.
  */
 
 import { transport } from './client';


### PR DESCRIPTION
## Summary

Closes #32. Decision documentation for the `abilities.ts` → `client.ts` decoupling.

- Adds a `TODO(M7.2.5)` comment to `src/api/abilities.ts` explaining the refactor plan: convert `executeAbility` / `queryAbility` to a `useExecuteAbility()` hook that reads `useAuth().client` from wp-native-shell
- No runtime behavior change — the global `transport` import stays until `<WPNativeApp/>` is mounted in M7.2.5
- Cross-ref: the actual refactor + deletion of `client.ts` happens in M7.2.5 (#33)

## Why not refactor now?

The wp-native-shell `AuthProvider` isn't mounted yet — `useAuth().client` doesn't exist at runtime. Breaking the dependency now would cause a runtime crash. This PR documents exactly what M7.2.5 needs to change so it has a clear pointer.