### PR TITLE
refactor(auth): extract OAuth to sibling hook (#31)

### DIFF
--- a/app/login.tsx
+++ b/app/login.tsx
@@ -14,6 +14,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useAuth } from '../src/auth/context';
+import { useGoogleAuth } from '../src/auth/oauth';
 import { useTheme } from '../src/theme/context';
 import { Button, TextInput, Notice, GoogleSignInButton } from '../src/components';
 
@@ -21,7 +22,8 @@ type AuthMode = 'login' | 'register';
 
 export default function Login() {
     const router = useRouter();
-    const { login, register, loginWithGoogle, sessionExpired, clearSessionExpired, onboardingCompleted, googleEnabled } = useAuth();
+    const { login, register, sessionExpired, clearSessionExpired, onboardingCompleted, refreshUser } = useAuth();
+    const { loginWithGoogle, googleEnabled } = useGoogleAuth();
     const { colors, spacing, fontSize, fontFamily } = useTheme();
 
     const [mode, setMode] = useState<AuthMode>('login');
@@ -107,6 +109,8 @@ export default function Login() {
 
         try {
             const result = await loginWithGoogle();
+            // Tokens are stored by loginWithGoogle; sync AuthProvider state
+            await refreshUser();
             if (result.onboardingCompleted) {
                 router.replace('/(drawer)/feed');
             } else {

--- a/src/auth/context.tsx
+++ b/src/auth/context.tsx
@@ -5,19 +5,17 @@
  * AuthFetchTransport from @extrachill/api-client, with expo-secure-store
  * wired in via src/api/client.ts.
  *
- * OAuth config is fetched on init. Google Sign-In is lazily loaded when
- * triggered (requires native module, won't work in Expo Go).
+ * Google OAuth is handled by useGoogleAuth() in ./oauth.ts.
  */
 
+// TODO: M7.2.5 will replace this entire file with re-exports from wp-native-shell.
+
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
-import { Platform } from 'react-native';
-import type { AuthMeResponse, OAuthConfigResponse, OnboardingStatusResponse, OnboardingSubmitResponse } from '../types/api';
+import type { AuthMeResponse, OnboardingStatusResponse, OnboardingSubmitResponse } from '../types/api';
 import { api, transport } from '../api/client';
 import { executeAbility, queryAbility } from '../api/abilities';
 import { getDeviceId } from './storage';
-
-let googleSignInModule: typeof import('@react-native-google-signin/google-signin') | null = null;
-let oauthConfigCache: OAuthConfigResponse | null = null;
+import { signOutGoogle } from './oauth';
 
 interface AuthState {
     user: AuthMeResponse | null;
@@ -25,16 +23,15 @@ interface AuthState {
     isAuthenticated: boolean;
     sessionExpired: boolean;
     onboardingCompleted: boolean;
-    googleEnabled: boolean;
 }
 
 interface AuthContextValue extends AuthState {
     login: (identifier: string, password: string) => Promise<void>;
     register: (email: string, password: string, passwordConfirm: string) => Promise<{ onboardingCompleted: boolean }>;
-    loginWithGoogle: () => Promise<{ onboardingCompleted: boolean }>;
     completeOnboarding: (username: string, userIsArtist: boolean, userIsProfessional: boolean) => Promise<void>;
     logout: () => Promise<void>;
     clearSessionExpired: () => void;
+    refreshUser: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);
@@ -46,31 +43,6 @@ function parseExpiresAt(expiresAt: string): number {
     return Math.floor(new Date(expiresAt).getTime() / 1000);
 }
 
-/**
- * Lazily load and configure Google Sign-In.
- * Returns the module if available, null if native module not found.
- */
-async function getGoogleSignIn(config: OAuthConfigResponse): Promise<typeof import('@react-native-google-signin/google-signin') | null> {
-    if (googleSignInModule) return googleSignInModule;
-
-    try {
-        googleSignInModule = await import('@react-native-google-signin/google-signin');
-
-        const iosClientId = config.google.ios_client_id;
-        const webClientId = config.google.web_client_id;
-
-        googleSignInModule.GoogleSignin.configure({
-            iosClientId: Platform.OS === 'ios' ? iosClientId : undefined,
-            webClientId,
-            offlineAccess: false,
-        });
-
-        return googleSignInModule;
-    } catch {
-        return null;
-    }
-}
-
 export function AuthProvider({ children }: { children: React.ReactNode }) {
     const [state, setState] = useState<AuthState>({
         user: null,
@@ -78,7 +50,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isAuthenticated: false,
         sessionExpired: false,
         onboardingCompleted: true,
-        googleEnabled: false,
     });
 
     const handleAuthFailure = useCallback(() => {
@@ -97,15 +68,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         transport.setOnAuthFailure(handleAuthFailure);
         await transport.initialize();
 
-        // Fetch OAuth config (lazy-load Google Sign-In when actually used)
-        let googleEnabled = false;
-        try {
-            oauthConfigCache = await api.auth.getOAuthConfig();
-            googleEnabled = oauthConfigCache.google.enabled;
-        } catch {
-            // OAuth config fetch failed, Google Sign-In disabled
-        }
-
         if (!transport.hasTokens()) {
             setState({
                 user: null,
@@ -113,7 +75,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 isAuthenticated: false,
                 sessionExpired: false,
                 onboardingCompleted: true,
-                googleEnabled,
             });
             return;
         }
@@ -127,7 +88,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 isAuthenticated: true,
                 sessionExpired: false,
                 onboardingCompleted: onboardingStatus.completed,
-                googleEnabled,
             });
         } catch {
             setState({
@@ -136,7 +96,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 isAuthenticated: false,
                 sessionExpired: false,
                 onboardingCompleted: true,
-                googleEnabled,
             });
         }
     }, [handleAuthFailure]);
@@ -201,75 +160,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return { onboardingCompleted: response.onboarding_completed };
     }, []);
 
-    const loginWithGoogle = useCallback(async () => {
-        if (!oauthConfigCache) {
-            throw new Error('Google Sign-In not available');
-        }
-
-        const gsi = await getGoogleSignIn(oauthConfigCache);
-        if (!gsi) {
-            throw new Error('Google Sign-In requires a development build');
-        }
-
-        try {
-            await gsi.GoogleSignin.hasPlayServices();
-            const response = await gsi.GoogleSignin.signIn();
-
-            if (!gsi.isSuccessResponse(response)) {
-                throw new Error('Google Sign-In was cancelled');
-            }
-
-            const idToken = response.data.idToken;
-            if (!idToken) {
-                throw new Error('No ID token received from Google');
-            }
-
-            const deviceId = await getDeviceId();
-            const authResponse = await api.auth.loginWithGoogle({
-                id_token: idToken,
-                device_id: deviceId,
-                registration_source: 'extrachill-app',
-                registration_method: 'google',
-            });
-
-            await transport.setTokens({
-                accessToken: authResponse.access_token,
-                refreshToken: authResponse.refresh_token,
-                accessExpiresAt: parseExpiresAt(authResponse.access_expires_at),
-            });
-
-            const [me, onboardingStatus] = await Promise.all([
-                api.auth.me(),
-                queryAbility<OnboardingStatusResponse>('extrachill/get-onboarding-status'),
-            ]);
-
-            setState(prev => ({
-                ...prev,
-                user: me,
-                isLoading: false,
-                isAuthenticated: true,
-                sessionExpired: false,
-                onboardingCompleted: onboardingStatus.completed,
-            }));
-
-            return { onboardingCompleted: onboardingStatus.completed };
-        } catch (error) {
-            if (gsi.isErrorWithCode(error)) {
-                switch (error.code) {
-                    case gsi.statusCodes.SIGN_IN_CANCELLED:
-                        throw new Error('Sign-in cancelled');
-                    case gsi.statusCodes.IN_PROGRESS:
-                        throw new Error('Sign-in already in progress');
-                    case gsi.statusCodes.PLAY_SERVICES_NOT_AVAILABLE:
-                        throw new Error('Google Play Services not available');
-                    default:
-                        throw new Error('Google Sign-In failed');
-                }
-            }
-            throw error;
-        }
-    }, []);
-
     const completeOnboarding = useCallback(async (
         username: string,
         userIsArtist: boolean,
@@ -290,16 +180,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
     const logout = useCallback(async () => {
         // Sign out of Google if module was loaded
-        if (googleSignInModule) {
-            try {
-                const currentUser = await googleSignInModule.GoogleSignin.getCurrentUser();
-                if (currentUser) {
-                    await googleSignInModule.GoogleSignin.signOut();
-                }
-            } catch {
-                // Ignore Google sign-out errors
-            }
-        }
+        await signOutGoogle();
 
         try {
             if (transport.hasTokens()) {
@@ -325,8 +206,28 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         setState(prev => ({ ...prev, sessionExpired: false }));
     }, []);
 
+    const refreshUser = useCallback(async () => {
+        try {
+            const [me, onboardingStatus] = await Promise.all([
+                api.auth.me(),
+                queryAbility<OnboardingStatusResponse>('extrachill/get-onboarding-status'),
+            ]);
+
+            setState(prev => ({
+                ...prev,
+                user: me,
+                isLoading: false,
+                isAuthenticated: true,
+                sessionExpired: false,
+                onboardingCompleted: onboardingStatus.completed,
+            }));
+        } catch {
+            // If refresh fails, leave state unchanged
+        }
+    }, []);
+
     return (
-        <AuthContext.Provider value={{ ...state, login, register, loginWithGoogle, completeOnboarding, logout, clearSessionExpired }}>
+        <AuthContext.Provider value={{ ...state, login, register, completeOnboarding, logout, clearSessionExpired, refreshUser }}>
             {children}
         </AuthContext.Provider>
     );

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -1,0 +1,177 @@
+/**
+ * Google OAuth hook — extracted from context.tsx (M7.2.3).
+ *
+ * Handles Google Sign-In lazy loading, OAuth config fetching, and the
+ * loginWithGoogle action. The REST route for Google login still uses
+ * @extrachill/api-client — that retires in M8.
+ *
+ * Consumers call useGoogleAuth() alongside useAuth() from context.tsx.
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+import { Platform } from 'react-native';
+import type { OAuthConfigResponse, OnboardingStatusResponse } from '../types/api';
+import { api, transport } from '../api/client';
+import { queryAbility } from '../api/abilities';
+import { getDeviceId } from './storage';
+
+// ─── Module-level singletons ────────────────────────────────────────────────
+
+let googleSignInModule: typeof import('@react-native-google-signin/google-signin') | null = null;
+let oauthConfigCache: OAuthConfigResponse | null = null;
+
+/**
+ * Parse an access_expires_at ISO string into a Unix timestamp (seconds).
+ */
+function parseExpiresAt(expiresAt: string): number {
+    return Math.floor(new Date(expiresAt).getTime() / 1000);
+}
+
+/**
+ * Lazily load and configure Google Sign-In.
+ * Returns the module if available, null if native module not found.
+ */
+async function getGoogleSignIn(
+    config: OAuthConfigResponse,
+): Promise<typeof import('@react-native-google-signin/google-signin') | null> {
+    if (googleSignInModule) return googleSignInModule;
+
+    try {
+        googleSignInModule = await import('@react-native-google-signin/google-signin');
+
+        const iosClientId = config.google.ios_client_id;
+        const webClientId = config.google.web_client_id;
+
+        googleSignInModule.GoogleSignin.configure({
+            iosClientId: Platform.OS === 'ios' ? iosClientId : undefined,
+            webClientId,
+            offlineAccess: false,
+        });
+
+        return googleSignInModule;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Sign out of Google if the module was loaded. Safe to call even if the user
+ * never signed in with Google. Called by AuthProvider's logout() action.
+ */
+export async function signOutGoogle(): Promise<void> {
+    if (!googleSignInModule) return;
+
+    try {
+        const currentUser = await googleSignInModule.GoogleSignin.getCurrentUser();
+        if (currentUser) {
+            await googleSignInModule.GoogleSignin.signOut();
+        }
+    } catch {
+        // Ignore Google sign-out errors
+    }
+}
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export interface GoogleAuthState {
+    googleEnabled: boolean;
+}
+
+export interface GoogleAuthActions {
+    loginWithGoogle: () => Promise<{ onboardingCompleted: boolean }>;
+}
+
+// ─── Hook ────────────────────────────────────────────────────────────────────
+
+/**
+ * Provides Google OAuth state and actions.
+ *
+ * Fetches OAuth config on mount and exposes loginWithGoogle().
+ * The config fetch is fire-and-forget — failures silently disable Google.
+ *
+ * After loginWithGoogle() resolves, tokens are stored via the transport.
+ * The caller must trigger an auth state refresh (e.g. via useAuth().refreshUser())
+ * to update the AuthProvider's state.
+ */
+export function useGoogleAuth(): GoogleAuthState & GoogleAuthActions {
+    const [googleEnabled, setGoogleEnabled] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function fetchOAuthConfig() {
+            try {
+                oauthConfigCache = await api.auth.getOAuthConfig();
+                if (!cancelled) {
+                    setGoogleEnabled(oauthConfigCache.google.enabled);
+                }
+            } catch {
+                // OAuth config fetch failed, Google Sign-In stays disabled
+            }
+        }
+
+        fetchOAuthConfig();
+        return () => { cancelled = true; };
+    }, []);
+
+    const loginWithGoogle = useCallback(async (): Promise<{ onboardingCompleted: boolean }> => {
+        if (!oauthConfigCache) {
+            throw new Error('Google Sign-In not available');
+        }
+
+        const gsi = await getGoogleSignIn(oauthConfigCache);
+        if (!gsi) {
+            throw new Error('Google Sign-In requires a development build');
+        }
+
+        try {
+            await gsi.GoogleSignin.hasPlayServices();
+            const response = await gsi.GoogleSignin.signIn();
+
+            if (!gsi.isSuccessResponse(response)) {
+                throw new Error('Google Sign-In was cancelled');
+            }
+
+            const idToken = response.data.idToken;
+            if (!idToken) {
+                throw new Error('No ID token received from Google');
+            }
+
+            const deviceId = await getDeviceId();
+            const authResponse = await api.auth.loginWithGoogle({
+                id_token: idToken,
+                device_id: deviceId,
+                registration_source: 'extrachill-app',
+                registration_method: 'google',
+            });
+
+            await transport.setTokens({
+                accessToken: authResponse.access_token,
+                refreshToken: authResponse.refresh_token,
+                accessExpiresAt: parseExpiresAt(authResponse.access_expires_at),
+            });
+
+            const onboardingStatus = await queryAbility<OnboardingStatusResponse>(
+                'extrachill/get-onboarding-status',
+            );
+
+            return { onboardingCompleted: onboardingStatus.completed };
+        } catch (error) {
+            if (gsi.isErrorWithCode(error)) {
+                switch (error.code) {
+                    case gsi.statusCodes.SIGN_IN_CANCELLED:
+                        throw new Error('Sign-in cancelled');
+                    case gsi.statusCodes.IN_PROGRESS:
+                        throw new Error('Sign-in already in progress');
+                    case gsi.statusCodes.PLAY_SERVICES_NOT_AVAILABLE:
+                        throw new Error('Google Play Services not available');
+                    default:
+                        throw new Error('Google Sign-In failed');
+                }
+            }
+            throw error;
+        }
+    }, []);
+
+    return { googleEnabled, loginWithGoogle };
+}


### PR DESCRIPTION
## Summary

Closes #31 (partial — full `context.tsx` replacement happens in M7.2.5).

- **Extracts** all Google OAuth code (lazy loader, OAuthConfig fetch, `loginWithGoogle`, `googleEnabled`) from `src/auth/context.tsx` into a new `src/auth/oauth.ts`
- **Exports** a `useGoogleAuth()` hook that `app/login.tsx` calls alongside `useAuth()`
- **Adds** `refreshUser()` action to `AuthProvider` so callers can sync auth state after OAuth tokens are stored
- **Adds** `signOutGoogle()` helper called by `AuthProvider.logout()` to sign out of Google on logout
- **Shrinks** `context.tsx` from 343 → 244 lines (net −99 lines of OAuth code removed)

### What changed

| File | Change |
|---|---|
| `src/auth/oauth.ts` | **New** — `useGoogleAuth()` hook + `signOutGoogle()` helper |
| `src/auth/context.tsx` | Removed all OAuth code, added `refreshUser()`, added M7.2.5 TODO |
| `app/login.tsx` | Imports `useGoogleAuth()` from `./oauth`, calls `refreshUser()` after Google login |

### Why now

Prepares for M7.2.5 to replace `context.tsx` with re-exports from `wp-native-shell`. The OAuth bits don't have a wp-native-shell equivalent (deferred to post-v0.1 per wp-native#18), so they need their own home.

### Not in scope

- Mounting wp-native-shell's `AuthProvider` — that's M7.2.5 (#33)
- Deleting `@extrachill/api-client` usage — that's M7.2.4
- OAuth strategy migration — that's #36 / wp-native#18

### Type check

`npx tsc --noEmit` has 0 errors in changed files. Pre-existing errors in `extrachill.config.ts` and `src/auth/storage.ts` from M7.2.1/M7.2.2 are unrelated.