### PR TITLE
feat(layout): mount <WPNativeApp/> from wp-native-shell (M7.2.5)

### DIFF
--- a/app/(drawer)/_layout.tsx
+++ b/app/(drawer)/_layout.tsx
@@ -1,55 +1,26 @@
 /**
  * Drawer layout for authenticated app surfaces.
- * 
- * Protects all routes in this group - redirects to login if not authenticated.
+ *
+ * Auth gating moved to WPNativeApp's AuthGate — this component
+ * unconditionally renders the drawer. If the user isn't authenticated,
+ * AuthGate intercepts before this layout even mounts.
+ *
+ * Uses wp-native-shell's DrawerContent for the drawer menu items.
+ * EC's custom DrawerContent (src/components/DrawerContent.tsx) is
+ * kept alive for now but no longer mounted — M7.2.9 deletes it.
  */
 
-import { useEffect } from 'react';
-import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { Drawer } from 'expo-router/drawer';
-import { useRouter } from 'expo-router';
-import { useAuth } from '../../src/auth/context';
-import { useTheme } from '../../src/theme/context';
-import { DrawerContent } from '../../src/components/DrawerContent';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { DrawerContent } from 'wp-native-shell';
 
 export default function DrawerLayout() {
-    const router = useRouter();
-    const { isLoading, isAuthenticated } = useAuth();
-    const { colors } = useTheme();
-
-    useEffect(() => {
-        if (!isLoading && !isAuthenticated) {
-            router.replace('/login');
-        }
-    }, [isLoading, isAuthenticated, router]);
-
-    if (isLoading) {
-        return (
-            <View style={[styles.loading, { backgroundColor: colors.backgroundColor }]}>
-                <ActivityIndicator size="large" color={colors.textColor} />
-            </View>
-        );
-    }
-
-    if (!isAuthenticated) {
-        return null;
-    }
-
     return (
-        <Drawer
-            screenOptions={{
-                headerShown: false,
-                drawerType: 'front',
-            }}
-            drawerContent={(props) => <DrawerContent {...props} />}
-        />
+        <GestureHandlerRootView style={{ flex: 1 }}>
+            <Drawer
+                drawerContent={(props) => <DrawerContent {...props} />}
+                screenOptions={{ headerShown: false, drawerType: 'front' }}
+            />
+        </GestureHandlerRootView>
     );
 }
-
-const styles = StyleSheet.create({
-    loading: {
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-    },
-});

--- a/app/(drawer)/feed.tsx
+++ b/app/(drawer)/feed.tsx
@@ -11,28 +11,27 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import type { DrawerNavigationProp } from '@react-navigation/drawer';
 import type { ParamListBase } from '@react-navigation/native';
 import { useNavigation } from 'expo-router';
-import { useAuth } from '../../src/auth/context';
-import { useTheme } from '../../src/theme/context';
+import { useAuth, useTheme } from 'wp-native-shell';
 import { Avatar } from '../../src/components';
 
 export default function Feed() {
     const navigation = useNavigation<DrawerNavigationProp<ParamListBase>>();
     const { user } = useAuth();
-    const { colors, spacing, fontSize, fontFamily } = useTheme();
+    const theme = useTheme();
 
     const openDrawer = () => {
         navigation.openDrawer();
     };
 
     return (
-        <SafeAreaView style={[styles.container, { backgroundColor: colors.backgroundColor }]} edges={['top']}>
+        <SafeAreaView style={[styles.container, { backgroundColor: theme.colors.background }]} edges={['top']}>
             <View
                 style={[
                     styles.header,
                     {
-                        backgroundColor: colors.headerBackground,
-                        paddingHorizontal: spacing.spacingMd,
-                        paddingVertical: spacing.spacingSm,
+                        backgroundColor: theme.colors.surface,
+                        paddingHorizontal: theme.spacing.md,
+                        paddingVertical: theme.spacing.sm,
                     },
                 ]}
             >
@@ -51,12 +50,12 @@ export default function Feed() {
                 <View style={styles.headerRight} />
             </View>
 
-            <View style={[styles.content, { padding: spacing.spacingXl }]}>
+            <View style={[styles.content, { padding: theme.spacing.xl }]}>
                 <Text
                     style={{
-                        color: colors.mutedText,
-                        fontSize: fontSize.fontSizeBase,
-                        fontFamily: fontFamily.body,
+                        color: theme.colors.textMuted,
+                        fontSize: theme.typography.fontSizes.base,
+                        fontFamily: theme.typography.fontFamily,
                         textAlign: 'center',
                     }}
                 >

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,20 @@
 /**
- * Root layout - wraps app with providers and loads fonts
+ * Root layout — mounts wp-native-shell's <WPNativeApp/> provider stack.
+ *
+ * WPNativeApp composes (outer → inner):
+ *   ThemeProvider → AuthProvider → NavigationConfigProvider →
+ *   BrowserHandoffProvider → AuthGate → {children}
+ *
+ * AuthGate intercepts unauthenticated users and renders LoginScreen.
+ * Authenticated users see expo-router's <Slot/> which renders the
+ * matched child route (index, onboarding, or the drawer group).
  */
 
-import { Stack } from 'expo-router';
+import { Slot } from 'expo-router';
 import { useFonts } from 'expo-font';
-import { AuthProvider } from '../src/auth/context';
-import { ThemeProvider } from '../src/theme/context';
+import { WPNativeApp } from 'wp-native-shell';
+import { config } from '../extrachill.config';
+import LoginScreen from './login';
 
 export default function RootLayout() {
     const [fontsLoaded] = useFonts({
@@ -18,10 +27,8 @@ export default function RootLayout() {
     }
 
     return (
-        <ThemeProvider>
-            <AuthProvider>
-                <Stack screenOptions={{ headerShown: false }} />
-            </AuthProvider>
-        </ThemeProvider>
+        <WPNativeApp config={config} loginScreen={LoginScreen}>
+            <Slot />
+        </WPNativeApp>
     );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,37 +1,79 @@
 /**
- * Entry point - redirects based on auth state
+ * Entry point — redirects based on onboarding status.
+ *
+ * Auth gating (login redirect) is handled by WPNativeApp's AuthGate.
+ * This screen only renders for authenticated users. It queries
+ * `extrachill/get-onboarding-status` via the shell's client and
+ * redirects to onboarding or the feed accordingly.
  */
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useAuth } from '../src/auth/context';
-import { useTheme } from '../src/theme/context';
+import { useAuth, useTheme } from 'wp-native-shell';
+
+interface OnboardingStatusResult {
+    completed: boolean;
+    fields: {
+        username: string;
+        user_is_artist: boolean;
+        user_is_professional: boolean;
+    };
+}
 
 export default function Index() {
     const router = useRouter();
-    const { isLoading, isAuthenticated, onboardingCompleted } = useAuth();
-    const { colors } = useTheme();
+    const { isLoading, isAuthenticated, client } = useAuth();
+    const theme = useTheme();
+    const [checking, setChecking] = useState(true);
 
     useEffect(() => {
-        if (isLoading) return;
+        if (isLoading || !isAuthenticated) return;
 
-        if (isAuthenticated) {
-            if (onboardingCompleted) {
-                router.replace('/(drawer)/feed');
-            } else {
-                router.replace('/onboarding');
+        let cancelled = false;
+
+        async function checkOnboarding() {
+            try {
+                const status = await client.execute<OnboardingStatusResult>(
+                    'extrachill/get-onboarding-status',
+                );
+
+                if (cancelled) return;
+
+                if (status.completed) {
+                    router.replace('/(drawer)/feed');
+                } else {
+                    router.replace('/onboarding');
+                }
+            } catch {
+                // If the onboarding check fails, assume complete and go to feed.
+                // This prevents a broken onboarding endpoint from locking users out.
+                if (!cancelled) {
+                    router.replace('/(drawer)/feed');
+                }
+            } finally {
+                if (!cancelled) {
+                    setChecking(false);
+                }
             }
-        } else {
-            router.replace('/login');
         }
-    }, [isLoading, isAuthenticated, onboardingCompleted, router]);
 
-    return (
-        <View style={[styles.container, { backgroundColor: colors.backgroundColor }]}>
-            <ActivityIndicator size="large" color={colors.textColor} />
-        </View>
-    );
+        void checkOnboarding();
+
+        return () => {
+            cancelled = true;
+        };
+    }, [isLoading, isAuthenticated, client, router]);
+
+    if (isLoading || checking) {
+        return (
+            <View style={[styles.container, { backgroundColor: theme.colors.background }]}>
+                <ActivityIndicator size="large" color={theme.colors.primary} />
+            </View>
+        );
+    }
+
+    return null;
 }
 
 const styles = StyleSheet.create({

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -1,5 +1,12 @@
 /**
- * Unified auth screen - handles both login and registration
+ * Unified auth screen — handles both login and registration.
+ *
+ * Uses wp-native-shell's useAuth() for login/register actions and
+ * useGoogleAuth() from src/auth/oauth for Google Sign-In.
+ *
+ * After successful auth, queries `extrachill/get-onboarding-status`
+ * via shell's client to determine whether to redirect to onboarding
+ * or the feed.
  */
 
 import { useState, useEffect } from 'react';
@@ -13,18 +20,48 @@ import {
     Pressable,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useAuth } from '../src/auth/context';
+import { useAuth, useTheme } from 'wp-native-shell';
 import { useGoogleAuth } from '../src/auth/oauth';
-import { useTheme } from '../src/theme/context';
 import { Button, TextInput, Notice, GoogleSignInButton } from '../src/components';
 
 type AuthMode = 'login' | 'register';
 
+interface OnboardingStatusResult {
+    completed: boolean;
+    fields: {
+        username: string;
+        user_is_artist: boolean;
+        user_is_professional: boolean;
+    };
+}
+
+/**
+ * Query onboarding status and navigate to the right screen.
+ * Falls back to feed on error (don't lock users out).
+ */
+async function navigatePostAuth(
+    client: ReturnType<typeof useAuth>['client'],
+    router: ReturnType<typeof useRouter>,
+): Promise<void> {
+    try {
+        const status = await client.execute<OnboardingStatusResult>(
+            'extrachill/get-onboarding-status',
+        );
+        if (status.completed) {
+            router.replace('/(drawer)/feed');
+        } else {
+            router.replace('/onboarding');
+        }
+    } catch {
+        router.replace('/(drawer)/feed');
+    }
+}
+
 export default function Login() {
     const router = useRouter();
-    const { login, register, sessionExpired, clearSessionExpired, onboardingCompleted, refreshUser } = useAuth();
+    const { login, register, sessionExpired, clearSessionExpired, client, refreshSession } = useAuth();
     const { loginWithGoogle, googleEnabled } = useGoogleAuth();
-    const { colors, spacing, fontSize, fontFamily } = useTheme();
+    const theme = useTheme();
 
     const [mode, setMode] = useState<AuthMode>('login');
     const [email, setEmail] = useState('');
@@ -61,11 +98,7 @@ export default function Login() {
             setIsSubmitting(true);
             try {
                 await login(email.trim(), password);
-                if (onboardingCompleted) {
-                    router.replace('/(drawer)/feed');
-                } else {
-                    router.replace('/onboarding');
-                }
+                await navigatePostAuth(client, router);
             } catch (err) {
                 setError(err instanceof Error ? err.message : 'Login failed');
             } finally {
@@ -89,12 +122,8 @@ export default function Login() {
 
             setIsSubmitting(true);
             try {
-                const result = await register(email.trim(), password, passwordConfirm);
-                if (result.onboardingCompleted) {
-                    router.replace('/(drawer)/feed');
-                } else {
-                    router.replace('/onboarding');
-                }
+                await register(email.trim(), password, passwordConfirm);
+                await navigatePostAuth(client, router);
             } catch (err) {
                 setError(err instanceof Error ? err.message : 'Registration failed');
             } finally {
@@ -109,8 +138,8 @@ export default function Login() {
 
         try {
             const result = await loginWithGoogle();
-            // Tokens are stored by loginWithGoogle; sync AuthProvider state
-            await refreshUser();
+            // Tokens stored by loginWithGoogle; sync shell's AuthProvider state.
+            await refreshSession();
             if (result.onboardingCompleted) {
                 router.replace('/(drawer)/feed');
             } else {
@@ -130,23 +159,23 @@ export default function Login() {
 
     return (
         <KeyboardAvoidingView
-            style={[styles.container, { backgroundColor: colors.backgroundColor }]}
+            style={[styles.container, { backgroundColor: theme.colors.background }]}
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
-            <View style={[styles.content, { paddingHorizontal: spacing.spacingXl }]}>
+            <View style={[styles.content, { paddingHorizontal: theme.spacing.xl }]}>
                 <Image
                     source={require('../assets/logo.png')}
-                    style={[styles.logo, { marginBottom: spacing.spacingLg }]}
+                    style={[styles.logo, { marginBottom: theme.spacing.lg }]}
                     resizeMode="contain"
                 />
                 <Text
                     style={[
                         styles.subtitle,
-                        { 
-                            color: colors.mutedText, 
-                            fontSize: fontSize.fontSizeBase, 
-                            marginBottom: spacing.spacingXl,
-                            fontFamily: fontFamily.body,
+                        {
+                            color: theme.colors.textMuted,
+                            fontSize: theme.typography.fontSizes.base,
+                            marginBottom: theme.spacing.xl,
+                            fontFamily: theme.typography.fontFamily,
                         },
                     ]}
                 >
@@ -191,7 +220,7 @@ export default function Login() {
                     />
                 )}
 
-                <View style={{ marginTop: spacing.spacingSm }}>
+                <View style={{ marginTop: theme.spacing.sm }}>
                     <Button
                         variant="secondary"
                         size="large"
@@ -204,17 +233,17 @@ export default function Login() {
                 </View>
 
                 {googleEnabled && (
-                    <View style={[styles.dividerContainer, { marginTop: spacing.spacingLg }]}>
-                        <View style={[styles.dividerLine, { backgroundColor: colors.borderColor }]} />
-                        <Text style={[styles.dividerText, { color: colors.mutedText, fontFamily: fontFamily.body }]}>
+                    <View style={[styles.dividerContainer, { marginTop: theme.spacing.lg }]}>
+                        <View style={[styles.dividerLine, { backgroundColor: theme.colors.border }]} />
+                        <Text style={[styles.dividerText, { color: theme.colors.textMuted, fontFamily: theme.typography.fontFamily }]}>
                             or
                         </Text>
-                        <View style={[styles.dividerLine, { backgroundColor: colors.borderColor }]} />
+                        <View style={[styles.dividerLine, { backgroundColor: theme.colors.border }]} />
                     </View>
                 )}
 
                 {googleEnabled && (
-                    <View style={{ marginTop: spacing.spacingLg }}>
+                    <View style={{ marginTop: theme.spacing.lg }}>
                         <GoogleSignInButton
                             onPress={handleGoogleSignIn}
                             loading={isGoogleLoading}
@@ -223,12 +252,12 @@ export default function Login() {
                     </View>
                 )}
 
-                <View style={[styles.toggleContainer, { marginTop: spacing.spacingLg }]}>
-                    <Text style={[styles.toggleText, { color: colors.mutedText, fontFamily: fontFamily.body }]}>
+                <View style={[styles.toggleContainer, { marginTop: theme.spacing.lg }]}>
+                    <Text style={[styles.toggleText, { color: theme.colors.textMuted, fontFamily: theme.typography.fontFamily }]}>
                         {isLogin ? "Don't have an account? " : 'Already have an account? '}
                     </Text>
                     <Pressable onPress={() => switchMode(isLogin ? 'register' : 'login')} disabled={isAnyLoading}>
-                        <Text style={[styles.toggleLink, { color: colors.accent, fontFamily: fontFamily.body }]}>
+                        <Text style={[styles.toggleLink, { color: theme.colors.primary, fontFamily: theme.typography.fontFamily }]}>
                             {isLogin ? 'Create one' : 'Sign in'}
                         </Text>
                     </Pressable>

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,7 +1,12 @@
 /**
- * Onboarding screen - username selection and preferences
- * 
- * Shown after registration to set final username and optional artist/professional flags.
+ * Onboarding screen — username selection and preferences.
+ *
+ * Shown after registration to set final username and optional
+ * artist/professional flags.
+ *
+ * Uses wp-native-shell's useAuth().client for ability calls:
+ *   - `extrachill/get-onboarding-status` (initial data load)
+ *   - `extrachill/complete-onboarding` (submit)
  */
 
 import { useState, useEffect } from 'react';
@@ -14,17 +19,29 @@ import {
     ActivityIndicator,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { useAuth } from '../src/auth/context';
-import { useTheme } from '../src/theme/context';
-import { queryAbility } from '../src/api/abilities';
-import type { OnboardingStatusResponse } from '../src/types/api';
+import { useAuth, useTheme } from 'wp-native-shell';
 
 import { Button, TextInput, Notice, Checkbox } from '../src/components';
 
+interface OnboardingStatusResult {
+    completed: boolean;
+    fields: {
+        username: string;
+        user_is_artist: boolean;
+        user_is_professional: boolean;
+    };
+}
+
+interface OnboardingSubmitResult {
+    user: {
+        username: string;
+    };
+}
+
 export default function Onboarding() {
     const router = useRouter();
-    const { completeOnboarding } = useAuth();
-    const { colors, spacing, fontSize, fontFamily } = useTheme();
+    const { client } = useAuth();
+    const theme = useTheme();
 
     const [username, setUsername] = useState('');
     const [isArtist, setIsArtist] = useState(false);
@@ -34,21 +51,32 @@ export default function Onboarding() {
     const [isSubmitting, setIsSubmitting] = useState(false);
 
     useEffect(() => {
-        const fetchOnboardingStatus = async () => {
+        let cancelled = false;
+
+        async function fetchOnboardingStatus() {
             try {
-                const status = await queryAbility<OnboardingStatusResponse>('extrachill/get-onboarding-status');
+                const status = await client.execute<OnboardingStatusResult>(
+                    'extrachill/get-onboarding-status',
+                );
+                if (cancelled) return;
+
                 setUsername(status.fields.username);
                 setIsArtist(status.fields.user_is_artist);
                 setIsProfessional(status.fields.user_is_professional);
-            } catch (err) {
-                setError('Failed to load onboarding data');
+            } catch {
+                if (!cancelled) {
+                    setError('Failed to load onboarding data');
+                }
             } finally {
-                setIsLoading(false);
+                if (!cancelled) {
+                    setIsLoading(false);
+                }
             }
-        };
+        }
 
-        fetchOnboardingStatus();
-    }, []);
+        void fetchOnboardingStatus();
+        return () => { cancelled = true; };
+    }, [client]);
 
     const handleSubmit = async () => {
         setError(null);
@@ -78,7 +106,14 @@ export default function Onboarding() {
         setIsSubmitting(true);
 
         try {
-            await completeOnboarding(trimmedUsername, isArtist, isProfessional);
+            await client.execute<OnboardingSubmitResult>(
+                'extrachill/complete-onboarding',
+                {
+                    username: trimmedUsername,
+                    user_is_artist: isArtist,
+                    user_is_professional: isProfessional,
+                },
+            );
             router.replace('/(drawer)/feed');
         } catch (err) {
             setError(err instanceof Error ? err.message : 'Failed to complete setup');
@@ -89,26 +124,26 @@ export default function Onboarding() {
 
     if (isLoading) {
         return (
-            <View style={[styles.loadingContainer, { backgroundColor: colors.backgroundColor }]}>
-                <ActivityIndicator size="large" color={colors.textColor} />
+            <View style={[styles.loadingContainer, { backgroundColor: theme.colors.background }]}>
+                <ActivityIndicator size="large" color={theme.colors.primary} />
             </View>
         );
     }
 
     return (
         <KeyboardAvoidingView
-            style={[styles.container, { backgroundColor: colors.backgroundColor }]}
+            style={[styles.container, { backgroundColor: theme.colors.background }]}
             behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
-            <View style={[styles.content, { paddingHorizontal: spacing.spacingXl }]}>
+            <View style={[styles.content, { paddingHorizontal: theme.spacing.xl }]}>
                 <Text
                     style={[
                         styles.title,
                         {
-                            color: colors.textColor,
-                            fontSize: fontSize.fontSizeXl,
-                            fontFamily: fontFamily.heading,
-                            marginBottom: spacing.spacingSm,
+                            color: theme.colors.text,
+                            fontSize: theme.typography.fontSizes.xl,
+                            fontFamily: theme.typography.fontFamilyBold ?? theme.typography.fontFamily,
+                            marginBottom: theme.spacing.sm,
                         },
                     ]}
                 >
@@ -118,10 +153,10 @@ export default function Onboarding() {
                     style={[
                         styles.subtitle,
                         {
-                            color: colors.mutedText,
-                            fontSize: fontSize.fontSizeBase,
-                            fontFamily: fontFamily.body,
-                            marginBottom: spacing.spacingXl,
+                            color: theme.colors.textMuted,
+                            fontSize: theme.typography.fontSizes.base,
+                            fontFamily: theme.typography.fontFamily,
+                            marginBottom: theme.spacing.xl,
                         },
                     ]}
                 >
@@ -134,10 +169,10 @@ export default function Onboarding() {
                     style={[
                         styles.label,
                         {
-                            color: colors.textColor,
-                            fontSize: fontSize.fontSizeBase,
-                            fontFamily: fontFamily.body,
-                            marginBottom: spacing.spacingSm,
+                            color: theme.colors.text,
+                            fontSize: theme.typography.fontSizes.base,
+                            fontFamily: theme.typography.fontFamily,
+                            marginBottom: theme.spacing.sm,
                         },
                     ]}
                 >
@@ -157,18 +192,18 @@ export default function Onboarding() {
                     style={[
                         styles.hint,
                         {
-                            color: colors.mutedText,
-                            fontSize: fontSize.fontSizeSm,
-                            fontFamily: fontFamily.body,
-                            marginTop: -spacing.spacingSm,
-                            marginBottom: spacing.spacingLg,
+                            color: theme.colors.textMuted,
+                            fontSize: theme.typography.fontSizes.sm,
+                            fontFamily: theme.typography.fontFamily,
+                            marginTop: -theme.spacing.sm,
+                            marginBottom: theme.spacing.lg,
                         },
                     ]}
                 >
                     Letters, numbers, hyphens, and underscores only. 3-60 characters.
                 </Text>
 
-                <View style={[styles.checkboxGroup, { marginBottom: spacing.spacingLg }]}>
+                <View style={[styles.checkboxGroup, { marginBottom: theme.spacing.lg }]}>
                     <Checkbox
                         label="I love music"
                         checked={true}

--- a/extrachill.config.ts
+++ b/extrachill.config.ts
@@ -2,24 +2,20 @@
  * extrachill.config.ts — Extra Chill app config for wp-native-shell.
  *
  * Consumed by <WPNativeApp config={config}/> in app/_layout.tsx (M7.2.5).
- * Until then, this file is dormant — its presence verifies the SHELL.md
- * contract type-checks against EC's specifics.
+ *
+ * The 0.1.0 surface dropped `brand` and `onboarding` from WPNativeConfig.
+ * Brand strings are consumer-managed inline. Onboarding gating is
+ * consumer-side — extrachill-app handles it in app/index.tsx by querying
+ * the `extrachill/get-onboarding-status` ability directly.
  */
 
 import type { WPNativeConfig, AuthState } from 'wp-native-shell';
 import { secureStoreAdapter } from './src/auth/storage';
-import OnboardingScreen from './app/onboarding';
 
 export const config: WPNativeConfig = {
   api: {
     baseUrl: 'https://extrachill.com/wp-json',
     clientId: 'extrachill-app',
-    defaultHeaders: { 'ExtraChill-Client': 'app' },
-  },
-
-  brand: {
-    name: 'Extra Chill',
-    welcomeMessage: 'Welcome to Extra Chill',
   },
 
   tokenStorage: secureStoreAdapter,
@@ -45,23 +41,17 @@ export const config: WPNativeConfig = {
     handoffAbility: 'wp-native/auth-browser-handoff',
   },
 
-  // Theme overrides — pull EC-specific tokens, fall back to defaults
-  // for everything else. Spread merges via wp-native-shell's
-  // deepMergeTokens at runtime.
+  // Theme overrides — only override what we need; wp-native-shell's
+  // deepMergeTokens fills in defaults for everything else.
+  // TODO(M7.2): pull color tokens from @extrachill/tokens when the
+  // migration lands. For now, leave default colors from wp-native-shell.
   theme: {
-    colors: {
-      // TODO(M7.2): pull from @extrachill/tokens when the migration lands.
-      // For now, leave defaults from wp-native-shell.
-    },
     typography: {
       fontFamily: 'WilcoLoftSans',
       fontFamilyBold: 'WilcoLoftSans-Bold',
+      fontSizeBase: 16,
+      fontSizes: { xs: 12, sm: 14, base: 16, lg: 18, xl: 20, '2xl': 24 },
+      lineHeights: { tight: 1.2, normal: 1.5, relaxed: 1.75 },
     },
-  },
-
-  onboarding: {
-    enabled: true,
-    ability: 'extrachill/complete-onboarding',
-    screen: OnboardingScreen,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react-native-svg": "15.12.1",
         "react-native-worklets": "0.5.1",
         "wp-native-client": "^0.0.1",
-        "wp-native-shell": "^0.0.1"
+        "wp-native-shell": "^0.1.0"
       },
       "devDependencies": {
         "@types/react": "~19.1.0",
@@ -10221,17 +10221,15 @@
       "license": "GPL-2.0-or-later"
     },
     "node_modules/wp-native-shell": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/wp-native-shell/-/wp-native-shell-0.0.1.tgz",
-      "integrity": "sha512-yBQh70YarOKmHCSioSKLTkdPfXPqWXtVzFTL3YJgsoScHSxx9tligWE3BIpOz4x+ghSjp9lr9obhDnKJsk2wkg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wp-native-shell/-/wp-native-shell-0.1.0.tgz",
+      "integrity": "sha512-2ohCLbXzwTC4e2ppXkH3OblOeFj8UiA5KvcDvekdEn4njKJO+i2B0eRb7Ae8yOUsjjNUV7+pjROKTMd7xBGbkw==",
       "license": "GPL-2.0-or-later",
       "peerDependencies": {
-        "@react-navigation/drawer": ">=7",
-        "@react-navigation/native": ">=7",
-        "@react-navigation/native-stack": ">=7",
         "expo-router": ">=6",
         "react": ">=19",
         "react-native": ">=0.80",
+        "react-native-gesture-handler": ">=2",
         "wp-native-client": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-native-svg": "15.12.1",
     "react-native-worklets": "0.5.1",
     "wp-native-client": "^0.0.1",
-    "wp-native-shell": "^0.0.1"
+    "wp-native-shell": "^0.1.0"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/src/auth/storage.ts
+++ b/src/auth/storage.ts
@@ -1,13 +1,17 @@
 /**
- * Secure storage helpers for auth tokens and device ID
+ * Secure storage helpers for auth tokens and device ID.
+ *
+ * Provides two things:
+ * 1. Legacy helpers (getDeviceId, storeTokens, etc.) used by EC's
+ *    internal auth code (src/auth/context.tsx, src/auth/oauth.ts).
+ * 2. `secureStoreAdapter` — a TokenStorageAdapter for wp-native-shell.
+ *    Shell 0.1.0 uses a simple key-value interface (getItem/setItem/
+ *    removeItem); the transport layer handles serialisation internally.
  */
 
 import * as SecureStore from 'expo-secure-store';
 import * as Crypto from 'expo-crypto';
-import type {
-  TokenStorageAdapter,
-  StoredTokens as ShellStoredTokens,
-} from 'wp-native-shell';
+import type { TokenStorageAdapter } from 'wp-native-shell';
 
 const KEYS = {
     ACCESS_TOKEN: 'access_token',
@@ -66,32 +70,14 @@ export async function clearTokens(): Promise<void> {
 }
 
 /**
- * Adapter that wraps EC's expo-secure-store helpers into wp-native-shell's
- * TokenStorageAdapter interface. Used by extrachill.config.ts.
+ * wp-native-shell 0.1.0 TokenStorageAdapter.
+ *
+ * Simple key-value interface backed by expo-secure-store.
+ * The shell's AuthFetchTransport manages its own key scheme
+ * (e.g. "wp-native:access_token") and calls getItem/setItem/removeItem.
  */
 export const secureStoreAdapter: TokenStorageAdapter = {
-    load: async (): Promise<ShellStoredTokens | null> => {
-        const tokens = await getTokens();
-        if (
-            !tokens.accessToken ||
-            !tokens.refreshToken ||
-            tokens.accessExpiresAt === null
-        ) {
-            return null;
-        }
-        return {
-            accessToken: tokens.accessToken,
-            refreshToken: tokens.refreshToken,
-            accessExpiresAt: tokens.accessExpiresAt,
-        };
-    },
-    save: async (tokens: ShellStoredTokens): Promise<void> => {
-        await storeTokens(
-            tokens.accessToken,
-            tokens.refreshToken,
-            tokens.accessExpiresAt,
-        );
-    },
-    clear: clearTokens,
-    getDeviceId,
+    getItem: (key: string) => SecureStore.getItemAsync(key),
+    setItem: (key: string, value: string) => SecureStore.setItemAsync(key, value),
+    removeItem: (key: string) => SecureStore.deleteItemAsync(key),
 };


### PR DESCRIPTION
## Summary

Closes #33. Part of the [M7.2.x migration chain](https://github.com/Extra-Chill/extrachill-app/issues/27).

The moment of truth for the wp-native dogfood — **extrachill-app now boots through wp-native-shell's `<WPNativeApp/>`**. The custom `AuthProvider`, `ThemeProvider`, and `Stack` root are replaced by the shell's provider stack:

```
ThemeProvider
  AuthProvider
    NavigationConfigProvider
      BrowserHandoffProvider
        AuthGate
          <Slot/>  ← expo-router renders matched route
```

## Changes

### Dependencies
- `wp-native-shell` bumped `^0.0.1` → `^0.1.0` (expo-router rebase, `register()` added, `brand`/`onboarding` removed from config)

### Root layout (`app/_layout.tsx`)
- Replaced EC's custom `AuthProvider` + `ThemeProvider` + `Stack` with `<WPNativeApp config={config} loginScreen={LoginScreen}><Slot/></WPNativeApp>`
- Shell's `AuthGate` handles loading/logged-out/logged-in states

### Drawer layout (`app/(drawer)/_layout.tsx`)
- Auth guard logic removed — `AuthGate` handles it upstream
- Switched to `DrawerContent` from `wp-native-shell` (previously EC's custom `DrawerContent`)
- Added `GestureHandlerRootView` wrapper (required by expo-router/drawer)

### Screen migrations
All screens now import `useAuth` and `useTheme` from `wp-native-shell` instead of EC's custom providers:

| Screen | Key migration notes |
|---|---|
| `app/index.tsx` | `onboardingCompleted` replaced with `client.execute('extrachill/get-onboarding-status')` |
| `app/login.tsx` | Shell's `register()` returns `void` — onboarding check via `client.execute()` post-auth. `refreshUser` → `refreshSession`. Google button uses `useGoogleAuth()` from M7.2.3. |
| `app/onboarding.tsx` | `completeOnboarding` → `client.execute('extrachill/complete-onboarding', {...})`. `queryAbility` → `client.execute()`. |
| `app/(drawer)/feed.tsx` | Straightforward import swap. Theme tokens renamed (`colors.backgroundColor` → `theme.colors.background`, etc.) |

### Config (`extrachill.config.ts`)
- Removed `brand`, `onboarding`, `defaultHeaders` (dropped from `WPNativeConfig` in 0.1.0)
- Onboarding gating is now consumer-side (handled in `app/index.tsx`)

### Storage adapter (`src/auth/storage.ts`)
- `secureStoreAdapter` rewritten for shell 0.1.0's `getItem`/`setItem`/`removeItem` interface (was `load`/`save`/`clear`/`getDeviceId`)

## Out of scope (deferred)

These files are **kept alive** but no longer mounted — other dead-code references may exist. Follow-up PRs sweep them:

- `src/auth/context.tsx` — M7.2.6
- `src/api/client.ts` — M7.2.6
- `src/components/DrawerContent.tsx` — M7.2.9
- `src/theme/context.tsx` — M7.2.9

## Verification

- [x] `npx tsc --noEmit` exits 0
- [x] No `any` introduced
- [x] All screens import `useAuth` from `wp-native-shell`
- [x] `app/index.tsx` queries onboarding via `client.execute()`
- [x] `app/login.tsx` Google button uses `useGoogleAuth()` from `../src/auth/oauth`

## Runtime concerns

1. **Google OAuth token sync**: `loginWithGoogle()` stores tokens via EC's `transport.setTokens()` (the old API client). Shell's `AuthProvider` doesn't see those tokens. We call `refreshSession()` after Google login to sync, but this depends on the shell's transport being able to find the tokens. Since both now use `expo-secure-store` via the same adapter, the shell transport should pick them up on refresh — but **this path needs runtime testing**.

2. **Shell DrawerContent vs EC DrawerContent**: Shell's `DrawerContent` renders navigation sections from `config.navigation.sections`. EC's old drawer had profile links, artist management, settings URLs. The shell drawer won't have those — it renders the `feed` section only. **The drawer will look different.** This is expected; EC-specific drawer items will be re-added via the navigation config in follow-up issues.

3. **Theme token mapping**: EC's old theme used `colors.backgroundColor`, `colors.textColor`, `colors.accent`, `spacing.spacingLg`, `fontSize.fontSizeBase`, `fontFamily.body` etc. Shell uses `colors.background`, `colors.text`, `colors.primary`, `spacing.lg`, `typography.fontSizes.base`, `typography.fontFamily`. All callsites updated, but EC's internal components (Button, TextInput, etc.) still use the old theme — they import from `src/theme/context.tsx` which is kept alive.