### PR TITLE
chore: register extrachill-app with homeboy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+<!-- Managed by homeboy. Do not hand-edit. -->

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Extra Chill",
     "slug": "extrachill-app",
-    "version": "0.2.0",
+    "version": "0.4.0",
     "scheme": "extrachill",
     "orientation": "portrait",
     "icon": "./assets/icon.png",

--- a/homeboy.json
+++ b/homeboy.json
@@ -1,0 +1,19 @@
+{
+  "auto_cleanup": false,
+  "changelog_target": "CHANGELOG.md",
+  "extensions": {
+    "nodejs": {}
+  },
+  "id": "extrachill-app",
+  "remote_path": "",
+  "version_targets": [
+    {
+      "file": "package.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    },
+    {
+      "file": "app.json",
+      "pattern": "\"version\":\\s*\"([0-9.]+)\""
+    }
+  ]
+}


### PR DESCRIPTION
Registers the mobile app with homeboy for version + changelog management. Two version targets (package.json + app.json's expo.version, which had drifted to 0.2.0 vs package.json's 0.4.0 — aligned to 0.4.0). Native build + store submission stays out of scope; homeboy owns version ceremony only.