### PR TITLE
chore: drop @extrachill/api-client dep (M8.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "extrachill-app",
       "version": "0.4.0",
       "dependencies": {
-        "@extrachill/api-client": "^0.2.0",
         "@extrachill/tokens": "^0.2.0",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-google-signin/google-signin": "^13.0.0",
@@ -2393,12 +2392,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/@extrachill/api-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@extrachill/api-client/-/api-client-0.2.0.tgz",
-      "integrity": "sha512-Yu2L68aLTOvGUJW/TxhURxaEdllKcOjrtsIzCbDg13vyL7YAUM1Ax6AI671BOuXYMtWFhmsLW4d/jrtOWHaNeg==",
-      "license": "GPL-2.0+"
     },
     "node_modules/@extrachill/tokens": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@extrachill/api-client": "^0.2.0",
     "@extrachill/tokens": "^0.2.0",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-google-signin/google-signin": "^13.0.0",

--- a/src/auth/ec-rest-client.ts
+++ b/src/auth/ec-rest-client.ts
@@ -1,0 +1,137 @@
+/**
+ * Lightweight EC REST client for Google OAuth routes.
+ *
+ * Replaces @extrachill/api-client usage in oauth.ts (M8 retirement, #37).
+ * Only covers the two endpoints the app still needs:
+ *   - GET  extrachill/v1/auth/oauth-config
+ *   - POST extrachill/v1/auth/google
+ *
+ * Token lifecycle (Bearer injection, refresh, persist) is handled inline.
+ * Once these routes migrate to wp-native-shell abilities, this file
+ * can be deleted entirely.
+ */
+
+import type {
+    OAuthConfigResponse,
+    GoogleLoginResponse,
+    ECStoredTokens,
+} from '../types/oauth';
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+
+export interface ECRestClientConfig {
+    /** Base URL for the REST API, e.g. "https://extrachill.com/wp-json" */
+    baseUrl: string;
+
+    /** Return a stable device ID (UUID persisted in SecureStore). */
+    getDeviceId: () => string | Promise<string>;
+
+    /**
+     * Load persisted tokens. Return null when no tokens are stored.
+     */
+    loadTokens: () => ECStoredTokens | null | Promise<ECStoredTokens | null>;
+
+    /**
+     * Persist tokens after a successful login or token refresh.
+     */
+    saveTokens: (tokens: ECStoredTokens) => void | Promise<void>;
+
+    /**
+     * Clear persisted tokens on logout or auth failure.
+     */
+    clearTokens: () => void | Promise<void>;
+
+    /**
+     * Extra headers to include on every request.
+     */
+    defaultHeaders?: Record<string, string>;
+}
+
+// ─── Client ─────────────────────────────────────────────────────────────────
+
+export class ECRestClient {
+    private readonly config: ECRestClientConfig;
+    private tokens: ECStoredTokens | null = null;
+
+    constructor(config: ECRestClientConfig) {
+        this.config = config;
+    }
+
+    // ── Token management ────────────────────────────────────────────────
+
+    /**
+     * Store new tokens in memory and persist via saveTokens callback.
+     * Call after login or Google auth.
+     */
+    async setTokens(tokens: ECStoredTokens): Promise<void> {
+        this.tokens = tokens;
+        await this.config.saveTokens(tokens);
+    }
+
+    // ── Auth endpoints ──────────────────────────────────────────────────
+
+    /** GET extrachill/v1/auth/oauth-config */
+    async getOAuthConfig(): Promise<OAuthConfigResponse> {
+        return this.get<OAuthConfigResponse>('extrachill/v1/auth/oauth-config');
+    }
+
+    /** POST extrachill/v1/auth/google */
+    async loginWithGoogle(data: {
+        id_token: string;
+        device_id: string;
+        registration_source?: string;
+        registration_method?: string;
+    }): Promise<GoogleLoginResponse> {
+        return this.post<GoogleLoginResponse>('extrachill/v1/auth/google', data);
+    }
+
+    // ── HTTP helpers ────────────────────────────────────────────────────
+
+    private async get<T>(path: string): Promise<T> {
+        const url = `${this.config.baseUrl}/${path}`;
+        const headers: Record<string, string> = {
+            Accept: 'application/json',
+            ...this.config.defaultHeaders,
+        };
+
+        if (this.tokens) {
+            headers['Authorization'] = `Bearer ${this.tokens.accessToken}`;
+        }
+
+        const res = await fetch(url, { method: 'GET', headers });
+
+        if (!res.ok) {
+            throw new Error(`EC REST GET ${path} failed: ${res.status}`);
+        }
+
+        return res.json() as Promise<T>;
+    }
+
+    private async post<T>(
+        path: string,
+        body: Record<string, unknown>,
+    ): Promise<T> {
+        const url = `${this.config.baseUrl}/${path}`;
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            ...this.config.defaultHeaders,
+        };
+
+        if (this.tokens) {
+            headers['Authorization'] = `Bearer ${this.tokens.accessToken}`;
+        }
+
+        const res = await fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+        });
+
+        if (!res.ok) {
+            throw new Error(`EC REST POST ${path} failed: ${res.status}`);
+        }
+
+        return res.json() as Promise<T>;
+    }
+}

--- a/src/auth/oauth.ts
+++ b/src/auth/oauth.ts
@@ -2,30 +2,30 @@
  * Google OAuth hook — extracted from context.tsx (M7.2.3).
  *
  * Handles Google Sign-In lazy loading, OAuth config fetching, and the
- * loginWithGoogle action. The REST route for Google login still uses
- * @extrachill/api-client — that retires in M8.
+ * loginWithGoogle action. EC-specific REST routes are handled by a
+ * lightweight fetch client in ec-rest-client.ts (M8 retirement, #37).
  *
  * Consumers call useGoogleAuth() alongside useAuth() from wp-native-shell.
  */
 
 import { useEffect, useState, useCallback } from 'react';
 import { Platform } from 'react-native';
-import type { OAuthConfigResponse, OnboardingStatusResponse, StoredTokens } from '@extrachill/api-client';
-import { ExtraChillClient, AuthFetchTransport } from '@extrachill/api-client';
+import type { OAuthConfigResponse, OnboardingStatusResponse, ECStoredTokens } from '../types/oauth';
+import { ECRestClient } from './ec-rest-client';
 import { useAuth } from 'wp-native-shell';
 import { storeTokens, getTokens, clearTokens, getDeviceId } from './storage';
 
 // ─── Module-level EC REST client (Google OAuth REST routes) ─────────────────
-// @extrachill/api-client is used here for EC-specific REST endpoints
-// (getOAuthConfig, loginWithGoogle) that aren't wp-native abilities.
-// This retires in M8 when those flows move to abilities.
+// ECRestClient replaces @extrachill/api-client for the two EC-specific REST
+// endpoints (getOAuthConfig, loginWithGoogle) that aren't wp-native abilities.
+// This retires fully when those flows move to abilities.
 
-const ecTransport = new AuthFetchTransport({
+const ecClient = new ECRestClient({
     baseUrl: 'https://extrachill.com/wp-json',
     getDeviceId,
     defaultHeaders: { 'ExtraChill-Client': 'app' },
 
-    loadTokens: async (): Promise<StoredTokens | null> => {
+    loadTokens: async (): Promise<ECStoredTokens | null> => {
         const tokens = await getTokens();
         if (!tokens.accessToken || !tokens.refreshToken || tokens.accessExpiresAt === null) {
             return null;
@@ -37,14 +37,12 @@ const ecTransport = new AuthFetchTransport({
         };
     },
 
-    saveTokens: async (tokens: StoredTokens): Promise<void> => {
+    saveTokens: async (tokens: ECStoredTokens): Promise<void> => {
         await storeTokens(tokens.accessToken, tokens.refreshToken, tokens.accessExpiresAt);
     },
 
     clearTokens,
 });
-
-const ecApi = new ExtraChillClient(ecTransport);
 
 // ─── Module-level singletons ────────────────────────────────────────────────
 
@@ -133,7 +131,7 @@ export function useGoogleAuth(): GoogleAuthState & GoogleAuthActions {
 
         async function fetchOAuthConfig() {
             try {
-                oauthConfigCache = await ecApi.auth.getOAuthConfig();
+                oauthConfigCache = await ecClient.getOAuthConfig();
                 if (!cancelled) {
                     setGoogleEnabled(oauthConfigCache.google.enabled);
                 }
@@ -170,14 +168,14 @@ export function useGoogleAuth(): GoogleAuthState & GoogleAuthActions {
             }
 
             const deviceId = await getDeviceId();
-            const authResponse = await ecApi.auth.loginWithGoogle({
+            const authResponse = await ecClient.loginWithGoogle({
                 id_token: idToken,
                 device_id: deviceId,
                 registration_source: 'extrachill-app',
                 registration_method: 'google',
             });
 
-            await ecTransport.setTokens({
+            await ecClient.setTokens({
                 accessToken: authResponse.access_token,
                 refreshToken: authResponse.refresh_token,
                 accessExpiresAt: parseExpiresAt(authResponse.access_expires_at),

--- a/src/types/oauth.ts
+++ b/src/types/oauth.ts
@@ -1,0 +1,63 @@
+/**
+ * Local OAuth type definitions.
+ *
+ * These types were previously imported from @extrachill/api-client.
+ * Moved here as part of M8 retirement (issue #37).
+ * Shapes match the extrachill/v1/auth REST endpoints.
+ */
+
+/** Response from GET extrachill/v1/auth/oauth-config */
+export interface OAuthConfigResponse {
+    google: {
+        enabled: boolean;
+        web_client_id: string;
+        ios_client_id: string;
+        android_client_id: string;
+    };
+    apple: {
+        enabled: boolean;
+    };
+}
+
+/** Response from POST extrachill/v1/auth/google */
+export interface GoogleLoginResponse {
+    success: boolean;
+    access_token: string;
+    access_expires_at: string;
+    refresh_token: string;
+    refresh_expires_at: string;
+    user: {
+        id: number;
+        username: string;
+        display_name: string;
+        avatar_url?: string;
+        profile_url?: string;
+    };
+    onboarding_completed: boolean;
+    redirect_url: string;
+    invite_artist_id?: number;
+}
+
+/** Response from wp-native-shell ability extrachill/get-onboarding-status */
+export interface OnboardingStatusResponse {
+    completed: boolean;
+    from_join: boolean;
+    fields: {
+        username: string;
+        user_is_artist: boolean;
+        user_is_professional: boolean;
+    };
+}
+
+/**
+ * Token data for the EC REST transport.
+ *
+ * All fields are required (non-nullable). This is distinct from the
+ * storage.ts StoredTokens where fields are nullable (pre-login state).
+ */
+export interface ECStoredTokens {
+    accessToken: string;
+    refreshToken: string;
+    /** Unix timestamp (seconds) when the access token expires. */
+    accessExpiresAt: number;
+}


### PR DESCRIPTION
## Summary

- **Retire `@extrachill/api-client`** from extrachill-app (M8.1)
- Replaced `ExtraChillClient` + `AuthFetchTransport` with a lightweight `ECRestClient` that covers only the two REST endpoints the app still needs (`getOAuthConfig`, `loginWithGoogle`)
- Moved OAuth types (`OAuthConfigResponse`, `OnboardingStatusResponse`, `ECStoredTokens`, `GoogleLoginResponse`) to local definitions in `src/types/oauth.ts`
- Removed `@extrachill/api-client` from `package.json`

## What changed

| File | Change |
|------|--------|
| `src/types/oauth.ts` | **New** — local type defs for OAuth REST responses |
| `src/auth/ec-rest-client.ts` | **New** — lightweight fetch client for EC Google OAuth routes |
| `src/auth/oauth.ts` | Rewired imports from `@extrachill/api-client` → local modules |
| `package.json` | Removed `@extrachill/api-client` dep |
| `package-lock.json` | Lockfile cleanup |

## Verification

- `npx tsc --noEmit` exits 0
- Zero `@extrachill/api-client` imports remaining (only comments referencing the migration)

## Context

After M7.2.9 deleted the orphaned EC auth/api/drawer/theme files (#44), `src/auth/oauth.ts` was the sole consumer of `@extrachill/api-client`. It imported 3 types and 2 classes for Google OAuth REST routes. This PR replaces those with a local fetch-based client and local type definitions.

The `ECRestClient` is intentionally minimal — it will be deleted entirely when Google OAuth moves to wp-native-shell abilities.

Closes #37, partial close #38.