### PR TITLE
chore: bump @extrachill/tokens to ^0.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "extrachill-app",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "extrachill-app",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
-        "@extrachill/tokens": "^0.2.0",
+        "@extrachill/tokens": "^0.8.1",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-google-signin/google-signin": "^13.0.0",
         "@react-navigation/drawer": "^7.7.10",
@@ -2394,9 +2394,9 @@
       }
     },
     "node_modules/@extrachill/tokens": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@extrachill/tokens/-/tokens-0.2.0.tgz",
-      "integrity": "sha512-5vEjcX5qAQhjHoqD1nL3nsYzpiLiIGDilP6eDnJH7jektyZQ3HKN7C0Mkn5O3E2hwxwV5Fff0gh3uO8GFnLxnA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@extrachill/tokens/-/tokens-0.8.1.tgz",
+      "integrity": "sha512-xBXIYfg9LBSwUZNItdaVZiIStWiaVeaQ3wdw+0/PLki86+OCRneFY+6gHmf6NTnVSKKAp1MEKOt4QVseQpFhhA==",
       "license": "GPL-2.0+"
     },
     "node_modules/@isaacs/balanced-match": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@extrachill/tokens": "^0.2.0",
+    "@extrachill/tokens": "^0.8.1",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-google-signin/google-signin": "^13.0.0",
     "@react-navigation/drawer": "^7.7.10",


### PR DESCRIPTION
## Summary

Aligns `@extrachill/tokens` from `^0.2.0` → `^0.8.1` with the latest token release. Lockfile updated.

The dependency is declared (a `TODO` in `extrachill.config.ts` references pulling color tokens from it later) but not yet imported, so this is a low-risk version alignment to keep the workspace on a single tokens version.